### PR TITLE
QA-15046: flush related caches before calculating invalid memberships

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
     <parent>
         <artifactId>jahia-modules</artifactId>
         <groupId>org.jahia.modules</groupId>
-        <version>8.1.0.1</version>
+        <version>8.2.0.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.jahia.modules</groupId>
+    <groupId>org.jahia.support.modules</groupId>
     <artifactId>user-cleanup-tool</artifactId>
     <name>User Cleanup Tool</name>
     <version>2.1.0-SNAPSHOT</version>
@@ -64,10 +64,6 @@
         <url>https://github.com/Jahia/user-cleanup-tool</url>
         <tag>HEAD</tag>
     </scm>
-
-    <properties>
-        <jahia-module-signature>MCwCFC0yzEtX5v9DUTCqz0fg2KOWFadLAhQn2V6xXD3CERVtIN+q5U/Zk2Wl6g==</jahia-module-signature>
-    </properties>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,11 @@
                 <configuration>
                     <instructions>
                         <Jahia-Depends>default</Jahia-Depends>
+                        <Import-Package>
+                            org.jahia.services.cache,
+                            ${jahia.plugin.projectPackageImport},
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/src/main/resources/tools/cleanup-users.jsp
+++ b/src/main/resources/tools/cleanup-users.jsp
@@ -67,6 +67,14 @@
 <c:set var="nextMember" value="${not empty param.nextMember ? param.nextMember : 0}"/>
 
 <%
+   
+    //flush user/group caches to get the correct results
+    org.jahia.services.cache.CacheHelper.flushEhcacheByName("LDAPUsersCache", true);
+    org.jahia.services.cache.CacheHelper.flushEhcacheByName("LDAPGroupCache", true);
+    org.jahia.services.cache.CacheHelper.flushEhcacheByName("org.jahia.services.usermanager.JahiaGroupManagerService.membershipCache", true);
+    org.jahia.services.cache.CacheHelper.flushEhcacheByName("org.jahia.services.usermanager.JahiaUserManagerService.userPathByUserNameCache", true);
+    org.jahia.services.cache.CacheHelper.flushEhcacheByName("org.jahia.services.usermanager.JahiaGroupManagerService.groupPathByGroupNameCache", true);
+   
     String[] acesToRemove = request.getParameterValues("acesToRemove");
     String[] membersToRemove = request.getParameterValues("membersToRemove");
 

--- a/src/main/resources/tools/cleanup-users.jsp
+++ b/src/main/resources/tools/cleanup-users.jsp
@@ -67,14 +67,7 @@
 <c:set var="nextMember" value="${not empty param.nextMember ? param.nextMember : 0}"/>
 
 <%
-   
-    //flush user/group caches to get the correct results
-    org.jahia.services.cache.CacheHelper.flushEhcacheByName("LDAPUsersCache", true);
-    org.jahia.services.cache.CacheHelper.flushEhcacheByName("LDAPGroupCache", true);
-    org.jahia.services.cache.CacheHelper.flushEhcacheByName("org.jahia.services.usermanager.JahiaGroupManagerService.membershipCache", true);
-    org.jahia.services.cache.CacheHelper.flushEhcacheByName("org.jahia.services.usermanager.JahiaUserManagerService.userPathByUserNameCache", true);
-    org.jahia.services.cache.CacheHelper.flushEhcacheByName("org.jahia.services.usermanager.JahiaGroupManagerService.groupPathByGroupNameCache", true);
-   
+
     String[] acesToRemove = request.getParameterValues("acesToRemove");
     String[] membersToRemove = request.getParameterValues("membersToRemove");
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-15046

## Description

Related user caches must be flushed before calculating the invalid memberships.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
