### PR TITLE
non existent j:member property should identify the user as invalid

### DIFF
--- a/src/main/java/org/jahia/modules/usercleanuptool/RemovalUtility.java
+++ b/src/main/java/org/jahia/modules/usercleanuptool/RemovalUtility.java
@@ -84,12 +84,12 @@ public final class RemovalUtility {
                 if (node.hasProperty("j:member")) {
                     String member = node.getPropertyAsString("j:member");
                     return node.getSession().getNodeByIdentifier(member) == null;
+                } else {
+                    return true; //jnt:member must have a j:member else it is invalid
                 }
             } catch (RepositoryException e) {
-                return true;
+                return true;  //in case of error return true
             }
-
-            return false;
         };
 
         return runQuery(query, pred, offset);


### PR DESCRIPTION
when jnt:member has no j:member attribute it should be identified as invalid